### PR TITLE
Support for VS2013 and VS2015

### DIFF
--- a/DynatraceAppMon/DynatraceAppMon.csproj
+++ b/DynatraceAppMon/DynatraceAppMon.csproj
@@ -162,10 +162,7 @@
       <HintPath>..\packages\Microsoft.VisualStudio.OLE.Interop.7.10.6070\lib\Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.14.0.14.1.24720\lib\Microsoft.VisualStudio.Shell.14.0.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.Shell.Immutable.10.0.10.0.30319\lib\net40\Microsoft.VisualStudio.Shell.Immutable.10.0.dll</HintPath>
       <Private>True</Private>
@@ -176,10 +173,6 @@
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.Shell.Immutable.12.0.12.0.21003\lib\net45\Microsoft.VisualStudio.Shell.Immutable.12.0.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Shell.Immutable.14.0.14.1.24720\lib\net45\Microsoft.VisualStudio.Shell.Immutable.14.0.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/DynatraceAppMon/Launcher.cs
+++ b/DynatraceAppMon/Launcher.cs
@@ -7,19 +7,17 @@ using DynaTrace.CodeLink;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Shell.Flavor;
 using Microsoft.VisualStudio.Shell;
-using System.Threading.Tasks;
 
 namespace FirstPackage
 {
     public class Launcher
     {
 
-        private string UNEXPECTED_DEFAULT_PROPERTY_VALUE = "dynaTrace_unexpected";
         private System.Diagnostics.Process lastRunningIIS = null;
         private DTE2 _applicationObject;
         private Context context;
 
-        private enum LaunchType { Assembly, WebApplication, WebSite };
+        private enum LaunchType { Assembly, WebApplication, WebSite, Unknown };
         /// <summary>
         /// web site project GUID refers to project type
         /// </summary>
@@ -223,6 +221,9 @@ namespace FirstPackage
                             break;
                         case LaunchType.Assembly:
                             LaunchProject(firstRunnable);
+                            break;
+                        case LaunchType.Unknown:
+                            System.Windows.Forms.MessageBox.Show("Unable to launch project, unsupported project type", "dynaTrace Launcher", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Error);
                             break;
                     }
                 }
@@ -435,12 +436,12 @@ namespace FirstPackage
             return null;
         }
 
-        private bool HasProperty(Project project, string propName)
+        private static bool HasProperty(Project project, string propName)
         {
             return HasProperty(project.Properties, propName);
         }
 
-        private bool HasProperty(Properties properties, string propName)
+        private static bool HasProperty(Properties properties, string propName)
         {
             //Dictionary<string, Object> props = new Dictionary<string, Object>();
             System.Collections.IEnumerator propEnum = properties.GetEnumerator();
@@ -469,12 +470,12 @@ namespace FirstPackage
         /// <param name="propName"></param>
         /// <param name="defaultValue"></param>
         /// <returns></returns>
-        private string GetProperty(Project project, string propName, string defaultValue)
+        private static string GetProperty(Project project, string propName, string defaultValue)
         {
             return GetProperty(project.Properties, propName, defaultValue);
         }
 
-        private string GetProperty(Properties properties, string propName, string defaultValue)
+        private static string GetProperty(Properties properties, string propName, string defaultValue)
         {
             if (HasProperty(properties, propName))
             {
@@ -562,17 +563,6 @@ namespace FirstPackage
             }
 
             return installPath;
-        }
-
-        private bool expectProperty(string propertyName, string propertyValue)
-        {
-            if (propertyValue == UNEXPECTED_DEFAULT_PROPERTY_VALUE)
-            {
-                context.log(Context.LOG_ERROR + "Missing project property \"" + propertyName + "\" in this project.");
-                System.Windows.Forms.MessageBox.Show("Could not launch application with dynaTrace support:\nMissing project property \"" + propertyName + "\"", "dynaTrace Launcher", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Warning);
-                return false;
-            }
-            return true;
         }
 
         private int GetDotNetFrameworkForProject(Project project)
@@ -708,17 +698,17 @@ namespace FirstPackage
                     return;
             }
 
+            StopLastRunningIIS();
+
             // we have to start the internal Microsoft WebServer
             string startProgram = "C:\\Program Files (x86)\\IIS Express\\iisexpress.exe";
             // WB string startWorking = System.IO.Path.GetDirectoryName(_addInInstance.DTE.FileName);
-            string startWorking = ".";
-            string ProjectPath = GetProperty(project, "FullPath", "");
-            string startArguments = "/config:\"" + ProjectPath + "..\\.vs\\config\\applicationhost.config\" /site:\"" + project.Name + "\" /apppool:\"Clr4IntegratedAppPool\"";
 
-            StopLastRunningIIS();
+            // for web application server command line gives only IIS parameters
+            string startArguments = GetProperty(project, "WebApplication.DevelopmentServerCommandLine", "");
 
             context.log(Context.LOG_INFO + "Starting new IIS Express instance with command line: " + startProgram + " " + startArguments);
-            lastRunningIIS = LaunchProcess(startProgram, startArguments, startWorking, "vs");
+            lastRunningIIS = LaunchProcess(startProgram, startArguments, ".", "vs");
 
             // now we start the browser with the correct page
             OpenWebBrowserWithDelay(launchURL, this.WaitForBrowserTime); 
@@ -728,11 +718,11 @@ namespace FirstPackage
         {
             context.log(Context.LOG_INFO + "Launching WebSite project");
 
-            // website web application config resides beside solution, DevelopmentServerCommandLine property gives proper command line
+            StopLastRunningIIS();
+
+            // website web application config resides beside solution, DevelopmentServerCommandLine property gives full command line
             string startProgram = GetProperty(project, "DevelopmentServerCommandLine", "");
 
-            StopLastRunningIIS();
-            
             context.log(Context.LOG_INFO + "Starting new IIS Express instance with command line: " + startProgram);
             lastRunningIIS = LaunchProcess(startProgram, "", ".", "vs");
 
@@ -751,52 +741,39 @@ namespace FirstPackage
         {
             // we have to start the output assembly
             // get all project related properties    
-            bool result = true;
-            string assemblyName = GetProperty(project, "AssemblyName", UNEXPECTED_DEFAULT_PROPERTY_VALUE);
-            result &= expectProperty("AssemblyName", assemblyName);
-            string projectFileName = System.IO.Path.GetDirectoryName(project.FileName);
-
-            Properties configProperties = project.ConfigurationManager.ActiveConfiguration.Properties;
-
-            string outputDir = GetProperty(configProperties, "OutputPath", UNEXPECTED_DEFAULT_PROPERTY_VALUE);
-            result &= expectProperty("OutputPath", outputDir);
-            string startArguments = GetProperty(configProperties, "StartArguments", UNEXPECTED_DEFAULT_PROPERTY_VALUE);
-            result &= expectProperty("StartArguments", startArguments);
-            string startWorking = GetProperty(configProperties, "StartWorkingDirectory", UNEXPECTED_DEFAULT_PROPERTY_VALUE);
-            result &= expectProperty("StartWorkingDirectory", startWorking);
-            string startProgram = GetProperty(configProperties, "StartProgram", UNEXPECTED_DEFAULT_PROPERTY_VALUE);
-            result &= expectProperty("StartProgram", startProgram);
+            var cfg = new AssemblyLauchConfig(project);
 
             // all required project properties found -> we can launch
-            if (result)
+            if (cfg.IsValid())
             {
+                string projectFileName = System.IO.Path.GetDirectoryName(project.FileName);
                 // ensure we have the correct path for the executable
                 if (!projectFileName.EndsWith("\\") && !projectFileName.EndsWith("/"))
                 {
                     projectFileName += "\\";
                 }
-                if (!outputDir.EndsWith("\\") && !outputDir.EndsWith("/"))
+                if (!cfg.OutputDir.EndsWith("\\") && !cfg.OutputDir.EndsWith("/"))
                 {
-                    outputDir += "\\";
+                    cfg.OutputDir += "\\";
                 }
-                if (outputDir.StartsWith("\\") || outputDir.StartsWith("/"))
+                if (cfg.OutputDir.StartsWith("\\") || cfg.OutputDir.StartsWith("/"))
                 {
-                    outputDir = outputDir.Substring(1);
+                    cfg.OutputDir = cfg.OutputDir.Substring(1);
                 }
 
                 // do we start an external program or our output?
-                if (startProgram == null || startProgram.Length <= 0)
+                if (cfg.StartProgram == null || cfg.StartProgram.Length <= 0)
                 {
-                    startProgram = String.Format("{0}{1}{2}.exe", projectFileName, outputDir, assemblyName);
+                    cfg.StartProgram = String.Format("{0}{1}{2}.exe", projectFileName, cfg.OutputDir, cfg.AssemblyName);
                 }
-                if (startWorking == null || startWorking.Length <= 0)
+                if (cfg.StartWorking == null || cfg.StartWorking.Length <= 0)
                 {
-                    startWorking = projectFileName + outputDir;
+                    cfg.StartWorking = projectFileName + cfg.OutputDir;
                 }
 
-                context.log(Context.LOG_INFO + "Launching Application: " + startProgram + ", Startarguments: " + startArguments + ", Workingdir: " + startWorking + ", Assembly: " + assemblyName);
+                context.log(Context.LOG_INFO + "Launching Application: " + cfg.StartProgram + ", Startarguments: " + cfg.StartArguments + ", Workingdir: " + cfg.StartWorking + ", Assembly: " + cfg.AssemblyName);
 
-                LaunchProcess(startProgram, startArguments, startWorking, assemblyName);
+                LaunchProcess(cfg.StartProgram, cfg.StartArguments, cfg.StartWorking, cfg.AssemblyName);
             }
             
         }
@@ -827,24 +804,77 @@ namespace FirstPackage
 
         private LaunchType GetProjectLaunchType(Project project)
         {
-            IVsSolution solution = (IVsSolution) Package.GetGlobalService(typeof(SVsSolution));
+            try { 
+                IVsSolution solution = (IVsSolution) Package.GetGlobalService(typeof(SVsSolution));
 
-            IVsHierarchy hierarchy = null;
-            solution.GetProjectOfUniqueName(project.UniqueName, out hierarchy);
+                IVsHierarchy hierarchy = null;
+                solution.GetProjectOfUniqueName(project.UniqueName, out hierarchy);
 
-            IVsAggregatableProjectCorrected AP = hierarchy as IVsAggregatableProjectCorrected;
-            string projTypeGuids = null;
-            AP.GetAggregateProjectTypeGuids(out projTypeGuids);
-            projTypeGuids = projTypeGuids.ToUpper();
+                IVsAggregatableProjectCorrected AP = hierarchy as IVsAggregatableProjectCorrected;
+                string projTypeGuids = null;
 
-            if (projTypeGuids.Contains(WEB_SITE_PROJECT_TYPE_GUID.ToUpper())) {
-                return LaunchType.WebSite;
-            } else if (projTypeGuids.Contains(WEB_APPLICATION_PROJECT_SUBTYPE_GUID.ToUpper())) {
-                return LaunchType.WebApplication;
+                // e.g. .NET core applications are not aggregable
+                if (AP != null)
+                {
+                    AP.GetAggregateProjectTypeGuids(out projTypeGuids);
+                    projTypeGuids = projTypeGuids.ToUpper();
+
+                    if (projTypeGuids.Contains(WEB_SITE_PROJECT_TYPE_GUID.ToUpper()))
+                    {
+                        return LaunchType.WebSite;
+                    }
+                    else if (projTypeGuids.Contains(WEB_APPLICATION_PROJECT_SUBTYPE_GUID.ToUpper()))
+                    {
+                        return LaunchType.WebApplication;
+                    }
+                }
+
+                if (new AssemblyLauchConfig(project).IsValid())
+                {
+                    return LaunchType.Assembly;
+                }
+            }
+            catch (Exception ex)
+            {
+                context.log(Context.LOG_ERROR + "Error while resolving project launch type: " + ex);
             }
 
-            return LaunchType.Assembly;
+            return LaunchType.Unknown;
         }
 
+        private bool ContainsLaunchAssemblyProperties()
+        {
+            throw new NotImplementedException();
+        }
+
+        private class AssemblyLauchConfig {
+
+            private string UNEXPECTED_DEFAULT_PROPERTY_VALUE = "dynaTrace_unexpected";
+
+            public string AssemblyName { get; set; }
+            public string OutputDir { get; set; }
+            public string StartArguments { get; set; }
+            public string StartWorking { get; set; }
+            public string StartProgram { get; set; }
+
+            public AssemblyLauchConfig(Project project) {
+
+                AssemblyName = GetProperty(project, "AssemblyName", UNEXPECTED_DEFAULT_PROPERTY_VALUE);
+
+                Properties configProperties = project.ConfigurationManager.ActiveConfiguration.Properties;
+                OutputDir = GetProperty(configProperties, "OutputPath", UNEXPECTED_DEFAULT_PROPERTY_VALUE);
+                StartArguments = GetProperty(configProperties, "StartArguments", UNEXPECTED_DEFAULT_PROPERTY_VALUE);
+                StartWorking = GetProperty(configProperties, "StartWorkingDirectory", UNEXPECTED_DEFAULT_PROPERTY_VALUE);
+                StartProgram = GetProperty(configProperties, "StartProgram", UNEXPECTED_DEFAULT_PROPERTY_VALUE);
+
+                List<String> propValues = new List<string>() { AssemblyName, OutputDir, StartArguments, StartWorking, StartProgram };
+            }
+
+            public bool IsValid() {
+                var allValues = new List<string>() { AssemblyName, OutputDir, StartArguments, StartWorking, StartProgram };
+                return !allValues.Contains(UNEXPECTED_DEFAULT_PROPERTY_VALUE);
+            } 
+
+        }
     }
 }

--- a/DynatraceAppMon/Launcher.cs
+++ b/DynatraceAppMon/Launcher.cs
@@ -823,7 +823,7 @@ namespace FirstPackage
                     {
                         return LaunchType.WebSite;
                     }
-                    else if (projTypeGuids.Contains(WEB_APPLICATION_PROJECT_SUBTYPE_GUID.ToUpper()))
+                    if (projTypeGuids.Contains(WEB_APPLICATION_PROJECT_SUBTYPE_GUID.ToUpper()))
                     {
                         return LaunchType.WebApplication;
                     }

--- a/DynatraceAppMon/RunTestsMenu.cs
+++ b/DynatraceAppMon/RunTestsMenu.cs
@@ -136,7 +136,9 @@ namespace FirstPackage
             if (result == 0)
             {
                 aggregatableProject = (IVsAggregatableProject)hierarchy;
-                result = aggregatableProject.GetAggregateProjectTypeGuids(out projectTypeGuids);
+                if (aggregatableProject != null) { 
+                    result = aggregatableProject.GetAggregateProjectTypeGuids(out projectTypeGuids);
+                }
             }
 
             return projectTypeGuids;

--- a/DynatraceAppMon/source.extension.vsixmanifest
+++ b/DynatraceAppMon/source.extension.vsixmanifest
@@ -1,31 +1,29 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="DynatraceAppMonExtension" Version="6.5.2" Language="en-US" Publisher="Dynatrace" />
+    <Identity Id="DynatraceAppMonExtension" Version="6.5.3" Language="en-US" Publisher="Dynatrace" />
     <DisplayName>Dynatrace AppMon</DisplayName>
     <Description xml:space="preserve">Integrate Visual Studion with Dynatrace AppMon.
 CodeLink - Automatically look up your source code from the Dynatrace AppMon client in Visual Studio. 
 Launch your .NET applications with an injected Dynatrace agent. 
 Run your unit tests with the Dynatrace agent.</Description>
-    <MoreInfo>https://community.dynatrace.com/community/display/DL/Dynatrace+AppMon+Visual+Studio+Extension</MoreInfo>
+    <MoreInfo>https://github.com/Dynatrace/Dynatrace-Visual-Studio-2017</MoreInfo>
     <License>dynaTraceBSD.txt</License>
     <Icon>dynatrace-icon.png</Icon>
     <PreviewImage>Signet_Logo.png</PreviewImage>
   </Metadata>
   <Installation>
-    <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Community" />
-    <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
+    <InstallationTarget Version="[12.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[12.0,16.0)" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[12.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
   </Installation>
   <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-    <Dependency Id="Microsoft.VisualStudio.MPF.14.0" DisplayName="Visual Studio MPF 14.0" d:Source="Installed" Version="[14.0]" />
+    <Dependency d:Source="Installed" Id="Microsoft.VisualStudio.MPF.12.0" DisplayName="Visual Studio MPF 12.0" Version="[12.0,13.0)" d:InstallSource="Download" />
   </Dependencies>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.Net.Core.Component.SDK" Version="[15.0.25904.2,16.0)" DisplayName=".NET Core 1.0.1 development tools" />
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.25904.2,16.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[12.0,16.0)" DisplayName="Visual Studio core editor" />
   </Prerequisites>
 </PackageManifest>

--- a/FAQ.md
+++ b/FAQ.md
@@ -8,9 +8,7 @@ Post any problems, questions or suggestions to the Dynatrace Community's [Applic
 
 * "External program" and "Don't open a page" start actions are not supported
 * The web application will always use IIS Express when started with the Dynatrace Launcher, even when another server is configured in the project settings
-* Default IIS Express application pool is used ("Clr4IntegratedAppPool")
 * Only default site name supported (named after the project)
-* Always launching IE browser
 * Two agents with the same name will connect to the Dynatrace Server: IIS Express and the IIS Express Tray which is a child process of IIS Express. Since the child process inherits environment variables from parents, the agent is also injected to that Tray application.
 
 ## Test Project

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The Dynatrace Visual Studio Extension enable you to launch applications with an 
 <a name="prerequisites"/>
 ### Prerequisites
 
-* Visual Studio Version: 2017 (all editions supported)
+* Visual Studio Version: 2017 (all editions supported), starting with plugin version 6.5.3 Visual Studio 2013 and 2015 are also supported 
 * Dynatrace AppMon Server 6.3+
 * Dynatrace AppMon .NET agent installed on your machine (to run/test your application with the .NET agent)
 * Dynatrace AppMon Client running on your machine (for CodeLink) 


### PR DESCRIPTION
- target platforms added: VS2013 and VS2015
- IIS command line resolving changed to work with VS2013
- project launch type check updated, unsupported types msg added (e.g. for .NET core projects)
- documentation updated